### PR TITLE
Add tests for anonymous posting

### DIFF
--- a/plugins/nodebb-plugin-composer-classroom/static/lib/composer/anonymous.js
+++ b/plugins/nodebb-plugin-composer-classroom/static/lib/composer/anonymous.js
@@ -8,12 +8,13 @@ function default_1() {
 	let displayBtn;
 	function handleClick() {
 		state.isToggled = Math.abs(state.isToggled - 1);
-		console.log(state.isToggled);
 	}
 	function init($postContainer) {
 		state.isToggled = 0;
 		displayBtn = $postContainer[0].querySelector('.display-anonymous-posting');
-		displayBtn === null || displayBtn === void 0 ? void 0 : displayBtn.addEventListener('click', handleClick);
+		if (displayBtn) {
+			displayBtn.addEventListener('click', handleClick);
+		}
 	}
 	function getBtnState() {
 		return state.isToggled;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -42,8 +42,6 @@ module.exports = function (Topics) {
             topicData.anonymous = 0;
         }
 
-        console.log(`Created topic with anonymous: ${topicData.anonymous}`);
-
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');
         }

--- a/test/topics.js
+++ b/test/topics.js
@@ -81,6 +81,21 @@ describe('Topic\'s', () => {
             });
         });
 
+        it('should create a new topic anonymously', (done) => {
+            topics.post({
+                uid: topic.userId,
+                title: topic.title,
+                content: topic.content,
+                cid: topic.categoryId,
+                anonymous: 1,
+            }, (err, result) => {
+                console.log('blop');
+                assert.ifError(err);
+                assert(result.topicData.anonymous === 1);
+                done();
+            });
+        });
+
         it('should get post count', (done) => {
             socketTopics.postcount({ uid: adminUid }, topic.tid, (err, count) => {
                 assert.ifError(err);

--- a/test/topics.js
+++ b/test/topics.js
@@ -89,9 +89,21 @@ describe('Topic\'s', () => {
                 cid: topic.categoryId,
                 anonymous: 1,
             }, (err, result) => {
-                console.log('blop');
                 assert.ifError(err);
                 assert(result.topicData.anonymous === 1);
+                done();
+            });
+        });
+
+        it('should default to creating new topics nonanonymously', (done) => {
+            topics.post({
+                uid: topic.userId,
+                title: topic.title,
+                content: topic.content,
+                cid: topic.categoryId,
+            }, (err, result) => {
+                assert.ifError(err);
+                assert.equal(result.topicData.anonymous, 0, 'defaulted to anonymous');
                 done();
             });
         });
@@ -285,6 +297,15 @@ describe('Topic\'s', () => {
                 assert.equal(err, null, 'was created with error');
                 assert.ok(result);
 
+                done();
+            });
+        });
+
+        it('should create a new anonymous reply', (done) => {
+            topics.reply({ uid: topic.userId, content: 'test post', tid: newTopic.tid, anonymous: 1 }, (err, result) => {
+                assert.equal(err, null, 'was created with error');
+                assert.ok(result);
+                assert.equal(result.anonymous, 1, 'was created nonanonymously');
                 done();
             });
         });

--- a/test/topics.js
+++ b/test/topics.js
@@ -90,6 +90,7 @@ describe('Topic\'s', () => {
                 anonymous: 1,
             }, (err, result) => {
                 assert.ifError(err);
+                assert(result.topicData.hasOwnProperty('anonymous'));
                 assert(result.topicData.anonymous === 1);
                 done();
             });
@@ -103,6 +104,7 @@ describe('Topic\'s', () => {
                 cid: topic.categoryId,
             }, (err, result) => {
                 assert.ifError(err);
+                assert(result.topicData.hasOwnProperty('anonymous'));
                 assert.equal(result.topicData.anonymous, 0, 'defaulted to anonymous');
                 done();
             });
@@ -305,6 +307,7 @@ describe('Topic\'s', () => {
             topics.reply({ uid: topic.userId, content: 'test post', tid: newTopic.tid, anonymous: 1 }, (err, result) => {
                 assert.equal(err, null, 'was created with error');
                 assert.ok(result);
+                assert(result.hasOwnProperty('anonymous'));
                 assert.equal(result.anonymous, 1, 'was created nonanonymously');
                 done();
             });


### PR DESCRIPTION
This adds tests of anonymous posting and default behavior of anonymous posting in `test/topics.js`, as well as removes console logging in several other files added for debugging. It also adds an explicit null check for the linter in `plugins/nodebb-plugin-composer-classroom/static/lib/composer/anonymous.js`.